### PR TITLE
Fixed failing test vestigial from pkl removal

### DIFF
--- a/src/data/tests/test_make_dataset.py
+++ b/src/data/tests/test_make_dataset.py
@@ -2,8 +2,7 @@
 # python3 -m pytest tests/
 import make_dataset
 import pandas as pd
-# import hashlib
-
+import pandas as pd
 
 def test_list_to_dict():
     assert make_dataset.list_to_dict(['Desktop', 'Tablet', 'Mobile', 'Desktop', 'Mobile', 'Desktop']) ==\
@@ -22,20 +21,15 @@ def test_aggregate_dict():
 
 
 # DATA PIPELINE
-# read some test data in
+# generate some test data in
+user_journey_dict = {
+     'Occurrences': [1, 12, 35],
+     'Sequence': ["/page1<<PAGE<:<NULL<:<NULL", "/page2<<PAGE<:<NULL<:<NULL", "/page1<<PAGE<:<NULL<:<NULL<<other>>/page2<<EVENT<:<yesNoFeedbackForm<:<ffNoClick<<other>>/page2<<EVENT<:<yesNoFeedbackForm<:<Send Form<<other"],
+     'PageSequence': ["/page1", "/page2", "/page1>>/page2>>/page2"]
+}
+
+user_journey_df = pd.DataFrame(user_journey_dict)
+
 def test_data_exists():
-    user_journey_df = None
-    user_journey_df = pd.read_pickle("./tests/user_journey_df.pkl")
     assert user_journey_df is not None
-    assert user_journey_df.shape == (100, 7)
-
-
-# read in and test Page Event and Page List creation
-# issue with logging affecting unit test, commented until fixed
-# def test_sequence_preprocess():
-#    user_journey_df = pd.read_pickle("./tests/user_journey_df.pkl")
-#    make_dataset.sequence_preprocess(user_journey_df)
-    # add 3 columns
-#    assert user_journey_df.shape == (100, 10)
-    # use checksum
-#    assert hashlib.sha256(user_journey_df.to_json().encode()).hexdigest()[:10] == 'b245049897'
+    assert user_journey_df.shape == (3, 3)


### PR DESCRIPTION
This test was failing. Fixed it by placeholder dataframe. This will allow expansion of unit tests to cover the steps in make_dataset, from user_journey_df to processed data

Closes #65 