### PR TITLE
Map taxons from node_list to their title, level, list of parents and level 1 parent

### DIFF
--- a/src/data/taxon_translate.py
+++ b/src/data/taxon_translate.py
@@ -1,5 +1,8 @@
-import pandas as pd
+import argparse
 import os
+
+import pandas as pd
+
 
 def recursive_parenting(df, content_id, parent_content_id, parent_list):
     """
@@ -68,4 +71,12 @@ def map_taxon_content_ids(nodes_list, taxon_path):
 
 
 if __name__ == "__main__":
-    taxon_path = os.path.join(os.getenv("DOCUMENTS"), "taxons.json.gz")
+    parser = argparse.ArgumentParser(
+        description='Module to translate taxon content_ids in node files to names. Also recursively compute parents.')
+    parser.add_argument('taxon_dir', help='File location of taxon json.')
+    parser.add_argument('dest_directory', help='Specialized destination directory for output dataframe file.')
+    parser.add_argument('output_filename', help='Naming convention for resulting merged dataframe file.')
+    parser.add_argument('-q', '--quiet', action='store_true', default=False, help='Turn off debugging logging.')
+    args = parser.parse_args()
+
+    taxon_path = os.path.join(args.taxon_dir, "taxons.json.gz")

--- a/src/data/taxon_translate.py
+++ b/src/data/taxon_translate.py
@@ -1,6 +1,6 @@
 def recursive_parenting(df, content_id, parent_content_id, parent_list):
     """
-    
+
     :param df:
     :param content_id:
     :param parent_content_id:
@@ -17,6 +17,15 @@ def recursive_parenting(df, content_id, parent_content_id, parent_list):
         title = df[df.content_id == content_id].iloc[0].title
         parent_list.append([content_id, parent_content_id, title])
         return recursive_parenting(df, content_id, parent_content_id, parent_list)
+
+
+def build_taxon_set(taxon_series):
+    """
+
+    :param taxon_series:
+    :return:
+    """
+    return set([content_id for taxon_list in taxon_series for content_id in taxon_list])
 
 
 if __name__ == "__main__":

--- a/src/data/taxon_translate.py
+++ b/src/data/taxon_translate.py
@@ -37,8 +37,8 @@ def build_taxon_set(taxon_series):
 def map_taxon_content_ids(taxon_df, nodes_df):
     """
 
-    :param nodes_list:
-    :param taxon_path:
+    :param taxon_df:
+    :param nodes_df:
     :return:
     """
 
@@ -68,6 +68,24 @@ def map_taxon_content_ids(taxon_df, nodes_df):
     return taxon_level_df
 
 
+def add_taxon_basepath_to_df(node_df, taxons_df):
+    """
+    
+    :param node_df:
+    :param taxons_df:
+    :return:
+    """
+    content_basepath_dict = dict(zip(taxons_df.content_id, taxons_df.base_path))
+    taxon_name_list = []
+    for tup in node_df.itertuples():
+        taxon_basepath = []
+        for taxon in tup.Node_Taxon:
+            if taxon in content_basepath_dict.keys():
+                taxon_basepath.append(content_basepath_dict[taxon])
+        taxon_name_list.append(taxon_basepath)
+    node_df['Node_Taxon_basepath'] = taxon_name_list
+    return node_df
+
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
@@ -82,6 +100,12 @@ if __name__ == "__main__":
     nodes_path = os.path.join("", args.input_filename)
 
     if os.path.exists(taxons_path) and os.path.exists(nodes_path):
-        taxon_df = pd.read_json(taxons_path, compression="gzip")
-        node_df = pd.read_csv(nodes_path, sep="\t", compression="gzip")
-        map_taxon_content_ids(taxon_df, node_df)
+        taxons_json_df = pd.read_json(taxons_path, compression="gzip")
+        nodes_df = pd.read_csv(nodes_path, sep="\t", compression="gzip")
+        taxon_df = map_taxon_content_ids(taxons_json_df, nodes_df)
+        nodes_df = add_taxon_basepath_to_df(nodes_df, taxon_df)
+
+        # overwrite option? should it be an option or default?
+        nodes_df.to_csv(nodes_path, sep="\t", compression="gzip", index=False)
+        # save taxon-specific dataframe
+        taxon_df.to_csv(args.output_filename, compression="gzip", index=False)

--- a/src/data/taxon_translate.py
+++ b/src/data/taxon_translate.py
@@ -1,0 +1,23 @@
+def recursive_parenting(df, content_id, parent_content_id, parent_list):
+    """
+    
+    :param df:
+    :param content_id:
+    :param parent_content_id:
+    :param parent_list:
+    :return:
+    """
+    if isinstance(parent_content_id, float) and len(parent_list) == 0:
+        return []
+    elif isinstance(parent_content_id, float):
+        return [[thing, i + 1] for i, thing in enumerate(reversed(parent_list))]
+    else:
+        content_id = parent_content_id
+        parent_content_id = df[df.content_id == parent_content_id].iloc[0].parent_content_id
+        title = df[df.content_id == content_id].iloc[0].title
+        parent_list.append([content_id, parent_content_id, title])
+        return recursive_parenting(df, content_id, parent_content_id, parent_list)
+
+
+if __name__ == "__main__":
+    print()

--- a/src/data/taxon_translate.py
+++ b/src/data/taxon_translate.py
@@ -34,7 +34,7 @@ def build_taxon_set(taxon_series):
     return set([content_id for taxon_list in taxon_series for content_id in taxon_list])
 
 
-def map_taxon_content_ids(nodes_list, taxon_path):
+def map_taxon_content_ids(taxon_df, nodes_df):
     """
 
     :param nodes_list:
@@ -42,12 +42,10 @@ def map_taxon_content_ids(nodes_list, taxon_path):
     :return:
     """
 
-    taxon_df = pd.read_json(taxon_path, compression="gzip")
-
     column_list = ['content_id', 'title', 'level', 'parents', 'level1_parent']
     taxon_level_df = pd.DataFrame(columns=column_list)
 
-    taxon_set = build_taxon_set(nodes_list)
+    taxon_set = build_taxon_set(nodes_df.Node_Taxon)
 
     for content_id in taxon_set:
         if taxon_df[taxon_df.content_id == content_id].shape[0] > 0:
@@ -70,13 +68,20 @@ def map_taxon_content_ids(nodes_list, taxon_path):
     return taxon_level_df
 
 
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(
-        description='Module to translate taxon content_ids in node files to names. Also recursively compute parents.')
+        description='Module to translate taxon content_ids in node file to names. Also recursively compute parents.')
     parser.add_argument('taxon_dir', help='File location of taxon json.')
-    parser.add_argument('dest_directory', help='Specialized destination directory for output dataframe file.')
-    parser.add_argument('output_filename', help='Naming convention for resulting merged dataframe file.')
+    parser.add_argument('input_filename', help='Specialized destination directory for output dataframe file.')
+    parser.add_argument('output_filename', default="", help='Naming convention for resulting merged dataframe file.')
     parser.add_argument('-q', '--quiet', action='store_true', default=False, help='Turn off debugging logging.')
     args = parser.parse_args()
 
-    taxon_path = os.path.join(args.taxon_dir, "taxons.json.gz")
+    taxons_path = os.path.join(args.taxon_dir, "taxons.json.gz")
+    nodes_path = os.path.join("", args.input_filename)
+
+    if os.path.exists(taxons_path) and os.path.exists(nodes_path):
+        taxon_df = pd.read_json(taxons_path, compression="gzip")
+        node_df = pd.read_csv(nodes_path, sep="\t", compression="gzip")
+        map_taxon_content_ids(taxon_df, node_df)


### PR DESCRIPTION
Closes #69 , will probably be implemented as an independent script.
Input: node.csv.gz file and taxon.json.gz (from content-tagger or elsewhere)
Output: for now a dataframe with target taxon content_id, title, level, list of parents and level 1 parent